### PR TITLE
Release under threatgrid

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject scopula "0.2.0"
+(defproject threatgrid/scopula "0.2.0"
   :description "Offers a scope convention mechanism to enhance control access."
   :url "https://github.com/threatgrid/scopula"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
This should simplify creds management, as I initially didn't have access to the `scopula` org, so I tentatively chose to release it under `threatgrid`.