### PR TITLE
Add `scope-expand` function

### DIFF
--- a/README.org
+++ b/README.org
@@ -403,13 +403,13 @@ expanded raw scopes.
 
 #+begin_src clojure
 (deftest scopes-expand-test
-  (is (= #{"foo:write" "bar"}
+  (is (= #{"foo:write" "bar" "role+admin"}
          (sut/scopes-expand #{"role+admin"}
                             {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz"}
+  (is (= #{"foo:write" "bar" "baz" "role+admin"}
          (sut/scopes-expand #{"role+admin" "baz"}
                             {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz" "x" "y"}
+  (is (= #{"foo:write" "bar" "baz" "x" "y" "role+admin" "subrole+x"}
          (sut/scopes-expand #{"role+admin" "subrole+x" "baz"}
                             {"role+admin" #{"foo:write" "bar"}
                              "subrole+x" #{"x" "y"}}))))

--- a/README.org
+++ b/README.org
@@ -396,7 +396,24 @@ presenting messages to the customer.
                                 #{"foo" "bar:read"}))))
 #+end_src
 
+**** ~scopes-expand~
 
+The ~scopes-expand~ takes a set of scopes and a scope-aliases set and returned the
+expanded raw scopes.
+
+#+begin_src clojure
+(deftest scopes-expand-test
+  (is (= #{"foo:write" "bar"}
+         (sut/scopes-expand #{"role+admin"}
+                            {"role+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz"}
+         (sut/scopes-expand #{"role+admin" "baz"}
+                            {"role+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz" "x" "y"}
+         (sut/scopes-expand #{"role+admin" "subrole+x" "baz"}
+                            {"role+admin" #{"foo:write" "bar"}
+                             "subrole+x" #{"x" "y"}}))))
+#+end_src
 
 *** Notes
 

--- a/README.org
+++ b/README.org
@@ -403,16 +403,22 @@ expanded raw scopes.
 
 #+begin_src clojure
 (deftest scopes-expand-test
-  (is (= #{"foo:write" "bar" "role+admin"}
-         (sut/scopes-expand #{"role+admin"}
-                            {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz" "role+admin"}
-         (sut/scopes-expand #{"role+admin" "baz"}
-                            {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz" "x" "y" "role+admin" "subrole+x"}
-         (sut/scopes-expand #{"role+admin" "subrole+x" "baz"}
-                            {"role+admin" #{"foo:write" "bar"}
-                             "subrole+x" #{"x" "y"}}))))
+  (is (= #{"foo:write" "bar"}
+         (sut/scopes-expand #{"+admin"} {"+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz"}
+         (sut/scopes-expand #{"+admin" "baz"} {"+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz" "subrole+x"}
+         (sut/scopes-expand #{"+admin" "subrole+x" "baz"} {"+admin" #{"foo:write" "bar"}
+                                                           "+x"     #{"x" "y"}})))
+  (is (= #{"admin"}
+         (sut/scopes-expand #{"admin"} {"admin" #{"foo"}}))
+      "scope expansion should only be performed on scope aliases starting with +")
+
+  (testing "missing scope alias"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/scopes-expand #{"+admin"} {})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/scopes-expand #{"+admin"} {"admin" #{"foo"}})))))
 #+end_src
 
 *** Notes

--- a/README.org
+++ b/README.org
@@ -398,7 +398,7 @@ presenting messages to the customer.
 
 **** ~scopes-expand~
 
-The ~scopes-expand~ takes a set of scopes and a scope-aliases set and returned the
+The ~scopes-expand~ takes a set of scopes and a scope-aliases set and returns the
 expanded raw scopes.
 
 #+begin_src clojure

--- a/README.org
+++ b/README.org
@@ -421,6 +421,57 @@ expanded raw scopes.
                  (sut/scopes-expand #{"+admin"} {"admin" #{"foo"}})))))
 #+end_src
 
+**** ~scopes-length~
+
+This functions takes a set of scopes as input and return the sum of the lengths
+of all scopes it contains.
+
+#+begin_src clojure
+(deftest scopes-length-test
+  (is (= 0 (sut/scopes-length #{})))
+  (is (= 3 (sut/scopes-length #{"foo"})))
+  (is (= 9 (sut/scopes-length #{"foo" "bar" "baz"})))
+  (is (= 22 (sut/scopes-length #{"foo/bar/baz" "foo" "foo:read"})))
+  (is (= 11 (sut/scopes-length #{"foo-bar-baz"}))))
+#+end_src
+
+**** ~scopes-compress~
+
+A function using a fast heuristic to try to use scopes aliases to reduce the
+size of a set of scopes.
+It is more important to have a fast non optimal result than to lose time trying
+to achieve optimal compression as this appear to be an NP-complete problem.
+
+This function is intended to be used in places where we don't care too much
+about reaching optimal compression but just doing a best effort in finding a
+shorter scopes set description that could easily be expanded to the full set of scopes.
+
+#+begin_src clojure
+(deftest scopes-compress-test
+  (is (= #{"+admin" "baz"}
+         (sut/scopes-compress #{"foo" "bar" "baz"}
+                              {"+admin" #{"foo" "bar"}
+                               "+foo" #{"foo"}}))
+      "This test check that the biggest matching alias is preferred to improve compression")
+  (is (= #{"+admin" "+baz" "x"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x"}
+                              {"+admin" #{"foo" "bar"}
+                               "+baz" #{"baz"}})))
+
+  (is (= #{"+admin" "+baz" "baz:write" "x"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x"}
+                              {"+admin" #{"foo" "bar"}
+                               "+baz" #{"baz:read"}})))
+  (is (= #{"foo" "bar" "baz" "+admin"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x" "very-very-long-scope-name"}
+                              {"+admin" #{"x" "very-very-long-scope-name"}
+                               "+baz" #{"foo" "bar" "x"}}))
+      (str "Example of potentially missing an opportunity to compress,"
+           " but show that the length of the string of scopes is more important"
+           " than the number of scopes."
+           " This is still a pretty good-enough for most intended use cases.")))
+#+end_src
+
 *** Notes
 
 The functions starting with =repr= takes scope representation as arguments. You

--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -439,12 +439,14 @@
 
 (defn- scopes-compress-first
   [scopes sorted-aliases]
-  (let [[alias-name scs] (first (filter (fn [[_ ss]] (scopes-subset? ss scopes)) sorted-aliases))]
+  (let [[alias-name sd] (first (keep (fn [[alias-name ss]]
+                                        (when (scopes-subset? ss scopes)
+                                          (try [alias-name (scope-difference scopes ss)]
+                                               (catch Exception _ nil))))
+                                     sorted-aliases))]
     (if alias-name
-      (try (-> (scope-difference scopes scs)
-               (conj alias-name))
-           (catch Exception _e
-             scopes))
+      (-> sd
+          (conj alias-name))
       scopes)))
 
 (defn scopes-compress

--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -480,11 +480,32 @@
           (conj alias-name))
       scopes)))
 
+(defn scopes-length
+  "Return the sum of the length of string in a set of scopes."
+  [scopes]
+  (reduce + (mapv count scopes)))
+
 (defn scopes-compress
-  "Given a set of scopes and a dictionary of scopes aliases try its best to compress scopes with scope aliases
-  To have the best possible compression is an NP-complete problem, so we just use a quick heuristic."
+  "Given a set of scopes and a dictionary of scopes aliases
+  use a fast heuristic to compress scopes with scope aliases.
+
+  It is more important to have a fast function than an efficient one.
+  The best possible compression is clearly an NP-complete problem.
+
+  What we do, we first sort aliases by the size of string that would be generated to list all the scopes.
+  So for example:
+
+  ```
+  {\"+foo\" {\"x\" \"y\"}
+  \"+bar\" {\"very-long-name-for-a-scope\"}
+  }
+  ```
+
+  the scope alias +bar will be preferred as even if the set contain fewer elements, the sum of the length
+  of the scopes in the scopes set is longer.
+  "
   [scopes aliases]
-  (let [sorted-aliases (sort-by (comp #(- %) count second) aliases)
+  (let [sorted-aliases (sort-by (comp #(- %) scopes-length second) aliases)
         compressed-scopes (scopes-compress-first scopes sorted-aliases)]
     (if (= scopes compressed-scopes)
       scopes

--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -50,9 +50,9 @@
   mean we should know all the sub-paths of some root-scope and add the difference.
 
   Scope are additive by nature."
-  (:require [clojure
-             [set :as set]
-             [string :as string]]))
+  (:require
+   [clojure.set :as set]
+   [clojure.string :as string]))
 
 (def allowed-chars-no-colon-no-slash "[!#-.0-9;-\\[\\]-~]")
 
@@ -476,8 +476,7 @@
                                                (catch Exception _ nil))))
                                      sorted-aliases))]
     (if alias-name
-      (-> sd
-          (conj alias-name))
+      (conj sd alias-name)
       scopes)))
 
 (defn scopes-length

--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -433,4 +433,7 @@
   (set
    (apply concat
          (for [s scopes]
-           (get aliases s [s])))))
+           (if-let [subs (get aliases s)]
+             (conj subs s)
+             [s])
+           ))))

--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -426,3 +426,11 @@
     (->> (repr-scopes-intersecting rs-1 rs-2)
          (map scope-repr-to-str)
          set)))
+
+(defn scopes-expand
+  "Given a list of scopes containing scope aliases expand them"
+  [scopes aliases]
+  (set
+   (apply concat
+         (for [s scopes]
+           (get aliases s [s])))))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -313,10 +313,21 @@
                                   #{"foo/bar:write" "bar:write"}))))
 
 (deftest scopes-expand-test
-  (is (= #{"foo:write" "bar" "role+admin"}
-         (sut/scopes-expand #{"role+admin"} {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz" "role+admin"}
-         (sut/scopes-expand #{"role+admin" "baz"} {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz" "x" "y" "role+admin" "subrole+x"}
-         (sut/scopes-expand #{"role+admin" "subrole+x" "baz"} {"role+admin" #{"foo:write" "bar"}
-                                                               "subrole+x" #{"x" "y"}}))))
+  (is (= #{"foo:write" "bar" "+admin"}
+         (sut/scopes-expand #{"+admin"} {"+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz" "+admin"}
+         (sut/scopes-expand #{"+admin" "baz"} {"+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz" "x" "y" "+admin" "+x"}
+         (sut/scopes-expand #{"+admin" "subrole+x" "baz"} {"+admin" #{"foo:write" "bar"}
+                                                           "+x"     #{"x" "y"}}))))
+
+(deftest scopes-compress-test
+  (is (= #{"+admin" "baz"}
+         (sut/scopes-compress #{"foo" "bar" "baz"}
+                              {"+admin" #{"foo" "bar"}
+                               "+foo" #{"foo"}}))
+      "This test check that the biggest matching alias is preferred to improve compression")
+  (is (= #{"+admin" "+baz" "x"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x"}
+                              {"+admin" #{"foo" "bar"}
+                               "+baz" #{"baz"}}))))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -353,6 +353,12 @@
     (is (nil?(sut/safe-scopes-expand #{"+admin"} {})))
     (is (nil? (sut/safe-scopes-expand #{"+admin"} {"admin" #{"foo"}})))))
 
+(deftest scopes-length-test
+  (is (= 0 (sut/scopes-length #{})))
+  (is (= 9 (sut/scopes-length #{"foo" "bar" "baz"})))
+  (is (= 22 (sut/scopes-length #{"foo/bar/baz" "foo" "foo:read"})))
+  (is (= 11 (sut/scopes-length #{"foo-bar-baz"}))))
+
 (deftest scopes-compress-test
   (is (= #{"+admin" "baz"}
          (sut/scopes-compress #{"foo" "bar" "baz"}
@@ -367,4 +373,12 @@
   (is (= #{"+admin" "+baz" "baz:write" "x"}
          (sut/scopes-compress #{"foo" "bar" "baz" "x"}
                               {"+admin" #{"foo" "bar"}
-                               "+baz" #{"baz:read"}}))))
+                               "+baz" #{"baz:read"}})))
+  (is (= #{"foo" "bar" "baz" "+admin"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x" "very-very-long-scope-name"}
+                              {"+admin" #{"x" "very-very-long-scope-name"}
+                               "+baz" #{"foo" "bar" "x"}}))
+      (str "Example of potentially missing an opportunity to compress,"
+           " but show that the length of the string of scopes is more important"
+           " than the number of scopes."
+           " This is still a pretty good-enough for most intended use cases.")))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -311,3 +311,12 @@
   (is (= #{}
          (sut/scopes-intersecting #{"foo:read" "bar:read"}
                                   #{"foo/bar:write" "bar:write"}))))
+
+(deftest scopes-expand-test
+  (is (= #{"foo:write" "bar"}
+         (sut/scopes-expand #{"role+admin"} {"role+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz"}
+         (sut/scopes-expand #{"role+admin" "baz"} {"role+admin" #{"foo:write" "bar"}})))
+  (is (= #{"foo:write" "bar" "baz" "x" "y"}
+         (sut/scopes-expand #{"role+admin" "subrole+x" "baz"} {"role+admin" #{"foo:write" "bar"}
+                                                               "subrole+x" #{"x" "y"}}))))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -355,6 +355,7 @@
 
 (deftest scopes-length-test
   (is (= 0 (sut/scopes-length #{})))
+  (is (= 3 (sut/scopes-length #{"foo"})))
   (is (= 9 (sut/scopes-length #{"foo" "bar" "baz"})))
   (is (= 22 (sut/scopes-length #{"foo/bar/baz" "foo" "foo:read"})))
   (is (= 11 (sut/scopes-length #{"foo-bar-baz"}))))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -330,4 +330,9 @@
   (is (= #{"+admin" "+baz" "x"}
          (sut/scopes-compress #{"foo" "bar" "baz" "x"}
                               {"+admin" #{"foo" "bar"}
-                               "+baz" #{"baz"}}))))
+                               "+baz" #{"baz"}})))
+
+  (is (= #{"+admin" "+baz" "baz:write" "x"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x"}
+                              {"+admin" #{"foo" "bar"}
+                               "+baz" #{"baz:read"}}))))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -313,10 +313,10 @@
                                   #{"foo/bar:write" "bar:write"}))))
 
 (deftest scopes-expand-test
-  (is (= #{"foo:write" "bar"}
+  (is (= #{"foo:write" "bar" "role+admin"}
          (sut/scopes-expand #{"role+admin"} {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz"}
+  (is (= #{"foo:write" "bar" "baz" "role+admin"}
          (sut/scopes-expand #{"role+admin" "baz"} {"role+admin" #{"foo:write" "bar"}})))
-  (is (= #{"foo:write" "bar" "baz" "x" "y"}
+  (is (= #{"foo:write" "bar" "baz" "x" "y" "role+admin" "subrole+x"}
          (sut/scopes-expand #{"role+admin" "subrole+x" "baz"} {"role+admin" #{"foo:write" "bar"}
                                                                "subrole+x" #{"x" "y"}}))))

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -314,7 +314,10 @@
 
 (deftest is-scopes-alias?
   (is (sut/is-scope-alias? "+foo"))
-  (is (not (sut/is-scope-alias? "foo"))))
+  (is (not (sut/is-scope-alias? "foo")))
+  (is (not (sut/is-scope-alias? "+foo/bar")))
+  (is (not (sut/is-scope-alias? "+foo:read")))
+  (is (not (sut/is-scope-alias? "+foo/bar:read"))))
 
 (deftest scopes-expand-test
   (is (= #{"foo:write" "bar"}


### PR DESCRIPTION
The goal is to provide a function that help compress scopes even more by introducing a notion of scopes aliases.

So the idea is that a scope for example `+admin` is equivalent to a set of scopes so after expansion we replace `+admin` by this set of scopes.