### PR TITLE
do not include empty aliases in the compressed scopes

### DIFF
--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -471,7 +471,8 @@
 (defn- scopes-compress-first
   [scopes sorted-aliases]
   (let [[alias-name sd] (first (keep (fn [[alias-name ss]]
-                                        (when (scopes-subset? ss scopes)
+                                        (when (and (scopes-subset? ss scopes)
+                                                   (seq ss))
                                           (try [alias-name (scope-difference scopes ss)]
                                                (catch Exception _ nil))))
                                      sorted-aliases))]

--- a/test/scopula/core_test.clj
+++ b/test/scopula/core_test.clj
@@ -370,6 +370,12 @@
          (sut/scopes-compress #{"foo" "bar" "baz" "x"}
                               {"+admin" #{"foo" "bar"}
                                "+baz" #{"baz"}})))
+  (is (= #{"+admin" "+baz" "x"}
+         (sut/scopes-compress #{"foo" "bar" "baz" "x"}
+                              {"+admin" #{"foo" "bar"}
+                               "+baz" #{"baz"}
+                               "+foo" #{}}))
+      "Make sure if the alias dictionary have an empty entry, the alias-name will not be included in the compressed-scopes")
 
   (is (= #{"+admin" "+baz" "baz:write" "x"}
          (sut/scopes-compress #{"foo" "bar" "baz" "x"}


### PR DESCRIPTION
Previously to this PR an empty entry in the scopes alias dictionary would be added to the compressed scopes result:

```clj
(is (= #{"+admin" "+baz" "x" "+foo"}
         (sut/scopes-compress #{"foo" "bar" "baz" "x"}
                              {"+admin" #{"foo" "bar"}
                               "+baz" #{"baz"}
                               "+foo" #{}})))
```

An additional check in scopes compression fixed it.