### PR TITLE
Support shorter accessors (:r and :w)

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,11 +45,15 @@ Here are some example for our convention:
 | =users/profile:read=        | access to users profile read-only             |
 | =users/profile/email:write= | access to users profile only email write-only |
 
+The generic format is a string with an optional single column ~:~.
+Before the ~:~ this represent a Resource Path.
+And after the ~:~ this represent a type of access, typically, ~read~, ~write~ or ~rw~.
 
-Mainly =:= is only authorized to split between access =read=/=write=/=rw=
-(nothing implies rw)
+If no ~:~ is present we consider the access to be ~rw~.
 
-Sub resources are separated by =/= we can
+So  ~RESOURCE_PATH:ACCESS~ where ~ACCESS~ could be ~r~, ~w~, ~read~, ~write~ or ~rw~.
+And where `RESOURCE_PATH` is a string that could contain multiple ~/~ to represent
+sub scopes.
 
 This library provide helper functions to check that users scope will also grants
 =users/profile/email= and =users/profile:read=

--- a/src/scopula/core.clj
+++ b/src/scopula/core.clj
@@ -61,7 +61,7 @@
 (def scope-regex (re-pattern (str
                               "^" allowed-word ;; root-scope
                               "(/" allowed-word ")*" ;; path of sub-scopes
-                              "(:(read|write|rw))?$" ;; read write or rw
+                              "(:(r|read|w|write|rw))?$" ;; read write or rw
                               )))
 
 (defn is-scope-format-valid?
@@ -84,7 +84,9 @@
     {:path (string/split path #"/")
      :access (case access
                "read"  #{:read}
+               "r"     #{:read}
                "write" #{:write}
+               "w"     #{:write}
                "rw"    #{:read :write}
                nil     #{:read :write}
                #{})}))


### PR DESCRIPTION
This PR allow the usage of `:r` for the scopes. 

I am still not sure this is a perfectly good idea because we will print message with the full `:read` accessor even if there is an error involving a scope written with `:r` for example which could cause confusion.